### PR TITLE
Switch testing to bionic

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent { 
         docker {
-            image "fluidity/baseimages:xenial"
+            image "fluidity/baseimages:bionic"
             label 'dockerhost'
         } 
     }


### PR DESCRIPTION
In line with the general move to python3, make the switch to Ubuntu Bionic which has 3 as the default python version. Xenial is now three years old and has been kept for historic rather than technical reasons; we have a full build stack for bionic ready to go.